### PR TITLE
ci: update build script

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -14,8 +14,8 @@ jobs:
       with:
         distribution: 'adopt'
         java-version: 11
-    - name: run assemble
-      run: ./gradlew assemble
+    - name: run shadowJar
+      run: ./gradlew shadowJar
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.4.0
-    - name: set up JDK 1.8
+    - name: set up JDK 11
       uses: actions/setup-java@v2
       with:
         distribution: 'adopt'
-        java-version: 8
+        java-version: 11
     - name: run assemble
       run: ./gradlew assemble
 
@@ -21,24 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.4.0
-    - name: set up JDK 1.8
+    - name: set up JDK 11
       uses: actions/setup-java@v2
       with:
         distribution: 'adopt'
-        java-version: 8
+        java-version: 11
     - name: run test
       run: ./gradlew test
-
-  analyze:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2.4.0
-    - name: set up JDK 1.8
-      uses: actions/setup-java@v2
-      with:
-        distribution: 'adopt'
-        java-version: 8
-    - name: run ktlintCheck
-      run: ./gradlew ktlintCheck
-    - name: run detektCheck
-      run: ./gradlew detektCheck

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -13,8 +13,8 @@ jobs:
       with:
         distribution: 'adopt'
         java-version: 11
-    - name: run assemble
-      run: ./gradlew assemble
+    - name: run shadowJar
+      run: ./gradlew shadowJar
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.4.0
-    - name: set up JDK 1.8
+    - name: set up JDK 11
       uses: actions/setup-java@v2
       with:
         distribution: 'adopt'
-        java-version: 8
+        java-version: 11
     - name: run assemble
       run: ./gradlew assemble
 
@@ -20,11 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.4.0
-    - name: set up JDK 1.8
+    - name: set up JDK 11
       uses: actions/setup-java@v2
       with:
         distribution: 'adopt'
-        java-version: 8
+        java-version: 11
     - name: run test
       run: ./gradlew test
 
@@ -32,11 +32,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.4.0
-    - name: set up JDK 1.8
+    - name: set up JDK 11
       uses: actions/setup-java@v2
       with:
         distribution: 'adopt'
-        java-version: 8
+        java-version: 11
     - name: run ktlintCheck
       run: ./gradlew ktlintCheck
 
@@ -44,45 +44,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.4.0
-    - name: set up JDK 1.8
+    - name: set up JDK 11
       uses: actions/setup-java@v2
       with:
         distribution: 'adopt'
-        java-version: 8
+        java-version: 11
     - name: run detektCheck
       run: ./gradlew detektCheck
-    - name: upload lint results
-      uses: actions/upload-artifact@v2
-      with:
-        name: lint
-        path: build/reports/
-
-  danger:
-    needs: [ test, analyze ]
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2.4.0
     - uses: actions/setup-ruby@v1.1.3
       with:
         ruby-version: '2.6'
-    - name: install bundler 2.1.2
-      run: gem install bundler:2.1.2
     - uses: actions/cache@v2.1.6
       with:
         path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('Gemfile') }}
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: |
           ${{ runner.os }}-gems-
-    - name: download lint results
-      uses: actions/download-artifact@v2
-      with:
-        name: lint
-        path: build/reports/
-    - uses: MeilCli/danger-action@v5.4.12
-      with:
-        plugins_file: 'Gemfile'
-        install_path: 'vendor/bundle'
-        danger_file: 'Dangerfile'
-        danger_id: 'danger-ci'
+    - name: bundle install
+      run: |
+        gem install bundler
+        bundle config path vendor/bundle
+        bundle install --without=documentation --jobs 4 --retry 3
+    - name: danger
+      run: bundle exec danger
       env:
         DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Orochi
 
-> TBC
+> Update multiple Anime/Manga trackers at the same time.
   
-Badges
+[![Master](https://github.com/Chesire/Orochi/actions/workflows/master.yml/badge.svg)](https://github.com/Chesire/Orochi/actions/workflows/master.yml)
 
 <!-- If Application
 > Google Play Link

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,13 +10,15 @@ plugins {
     kotlin("plugin.serialization") version "1.5.31"
     id("io.gitlab.arturbosch.detekt") version "1.18.0"
     id("org.jlleitschuh.gradle.ktlint") version "10.2.0"
+    id("com.github.johnrengelman.shadow") version "6.1.0"
 }
 
 group = "com.chesire"
 version = "0.0.1-SNAPSHOT"
 
+val appStart = "com.chesire.orochi.ApplicationKt"
 application {
-    mainClassName = "io.ktor.server.netty.EngineMain"
+    mainClassName = appStart
 }
 
 repositories {


### PR DESCRIPTION
## Description of the change
Update the GitHub actions build script to include various fixes.
* Build against JDK11 instead of 8
* Run a `shadowJar` task instead of just `assemble`
* Call `danger` manually, instead of relying on another action

close # 35
close #37 